### PR TITLE
[ACS-9269] 'selectAlternative' text appears on the login page even when no alternative providers are available

### DIFF
--- a/theme/login/login.ftl
+++ b/theme/login/login.ftl
@@ -38,7 +38,7 @@
                 </form>
             </div>
         </#if>
-        <#if social.providers??>
+        <#if social.providers?? && social.providers?has_content>
             <p class="para">${msg("selectAlternative")}</p>
             <div id="social-providers">
                 <#list social.providers as p>


### PR DESCRIPTION
Ticket: https://hyland.atlassian.net/browse/ACS-9269

Current Behaviour:
The text "Or select an alternative" appears on ADW login page even when no alternative login providers exist.

New  Behaviour:
The text is only displayed if alternative login providers are available.

